### PR TITLE
Integrate with semver-labeling action outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,68 @@
 # Create Release Action
 
-This action creates a release with a tag equal to the PR title with spaces and other invalid characters removed.
+Creates a GitHub release using semver version data from the [PR Semver Labeler](https://github.com/jkbeeman92/semver-labeling) action. Can also be used standalone by deriving a tag from the PR title.
 
 ## Inputs
 
-### `title`
-
-**Required** The title of the PR. Default `" "`.
-
-### `token`
-
-**Required** The GitHub token. Default `" "`.
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `title` | ✅ | — | PR title, used as the human-readable release name |
+| `token` | ✅ | — | GitHub token |
+| `semver` | ❌ | `""` | Full semver string from the semver-labeling action (e.g. `2.3.1` or `2.3.1-beta.1`). When provided, used as the tag instead of deriving one from the title. |
+| `semver_type` | ❌ | `""` | Release type from the semver-labeling action: `major`, `minor`, `patch`, or `pre-release`. Drives the prerelease flag on the GitHub release. |
+| `tag_prefix` | ❌ | `v` | Prefix prepended to the semver tag (e.g. `v` produces `v2.3.1`). Only applies when `semver` is provided. |
 
 ## Outputs
 
-None.
+| Output | Description |
+|---|---|
+| `release_url` | URL of the created GitHub release |
+| `tag_name` | The tag name used for the release |
 
-## Example usage
+## Usage with semver-labeling (recommended)
 
 ```yaml
-uses: actions/create-release@v1
-with:
-  title: ${{ github.event.pull_request.title }}
-  token: ${{ secrets.GITHUB_TOKEN }}
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect and label semver
+        id: semver
+        uses: jkbeeman92/semver-labeling@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create release
+        if: steps.semver.outputs.matched == 'true'
+        uses: jkbeeman92/create-release@v1
+        with:
+          title: ${{ github.event.pull_request.title }}
+          semver: ${{ steps.semver.outputs.semver }}
+          semver_type: ${{ steps.semver.outputs.semver_type }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+With a PR titled `v2.3.1 - new features`, this will:
+- Create a release tagged `v2.3.1`
+- Name the release `v2.3.1 - new features`
+- Mark it as a full release (not a prerelease)
+
+With a PR titled `v2.3.1-beta.1 - beta release`:
+- Creates a release tagged `v2.3.1-beta.1`
+- Marks it as a **prerelease** automatically
+
+## Standalone usage (no semver-labeling)
+
+If used without the semver-labeling action, the tag is derived from the PR title by stripping characters that are invalid in git tags.
+
+```yaml
+- uses: jkbeeman92/create-release@v1
+  with:
+    title: ${{ github.event.pull_request.title }}
+    token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,33 @@
 name: 'Create Release from PR Title'
-description: 'Create a release with a tag equal to the PR title with spaces removed'
-author: 'Your Name'
+description: 'Creates a GitHub release using semver version data from the PR Semver Labeler action'
+author: 'JKBeeman92'
 branding:
   icon: 'package'
   color: 'green'
 inputs:
   title:
-    description: 'PR title'
+    description: 'PR title — used as the human-readable release name'
     required: true
   token:
     description: 'GitHub token'
     required: true
+  semver:
+    description: 'Full semver string from the semver-labeling action (e.g. "2.3.1" or "2.3.1-beta.1"). When provided, this is used as the tag instead of deriving one from the title.'
+    required: false
+    default: ''
+  semver_type:
+    description: 'Release type from the semver-labeling action: "major", "minor", "patch", or "pre-release". Used to set the prerelease flag on the GitHub release.'
+    required: false
+    default: ''
+  tag_prefix:
+    description: 'Prefix to prepend to the semver tag (e.g. "v" produces "v2.3.1"). Only applies when semver input is provided.'
+    required: false
+    default: 'v'
+outputs:
+  release_url:
+    description: 'URL of the created GitHub release'
+  tag_name:
+    description: 'The tag name used for the release'
 runs:
   using: 'node20'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -5,25 +5,47 @@ async function run() {
     try {
         const title = core.getInput('title');
         const token = core.getInput('token');
+        const semver = core.getInput('semver');
+        const semverType = core.getInput('semver_type');
+        const tagPrefix = core.getInput('tag_prefix');
 
-        // Remove spaces and other invalid characters from PR title and create a tag
-        const tagName = title.replace(/[\s~^:?*[\]\/@{}\\]/g, '');
+        let tagName;
+        let isPreRelease = false;
+
+        if (semver) {
+            // Use the clean semver output from the semver-labeling action
+            tagName = `${tagPrefix}${semver}`;
+            isPreRelease = semverType === 'pre-release';
+        } else {
+            // Fallback: derive tag from PR title by stripping invalid git tag characters
+            tagName = title.replace(/[\s~^:?*[\]\/@{}\\]/g, '');
+        }
+
+        if (!tagName) {
+            core.setFailed('Tag name is empty. Ensure the PR title or semver input contains valid characters.');
+            return;
+        }
+
+        core.info(`Creating release with tag: ${tagName} (pre-release: ${isPreRelease})`);
 
         const octokit = github.getOctokit(token);
 
-        // Create a release
-        await octokit.rest.repos.createRelease({
+        const response = await octokit.rest.repos.createRelease({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             tag_name: tagName,
             name: title,
             generate_release_notes: true,
             draft: false,
-            prerelease: false
+            prerelease: isPreRelease
         });
 
+        core.setOutput('release_url', response.data.html_url);
+        core.setOutput('tag_name', tagName);
+        core.info(`Release created: ${response.data.html_url}`);
+
     } catch (error) {
-        core.setFailed(error.message);
+        core.setFailed(`Failed to create release: ${error.message}`);
     }
 }
 


### PR DESCRIPTION
- Add semver, semver_type, and tag_prefix inputs to action.yml
- Use semver output from semver-labeling as the tag instead of stripping PR title
- Set prerelease flag based on semver_type === 'pre-release'
- Emit release_url and tag_name as outputs for downstream steps
- Fall back to title-based tag derivation when semver input is not provided
- Add empty tag guard with a clear error message
- Update README with integration example and input/output docs